### PR TITLE
Allow anything for the children proptype of the Entity component

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ var Entity = exports.Entity = (function (_React$Component2) {
 })(_react2.default.Component);
 
 Entity.propTypes = {
-  children: _react2.default.PropTypes.array,
+  children: _react2.default.PropTypes.any,
   mixin: _react2.default.PropTypes.string,
   onClick: _react2.default.PropTypes.func,
   onLoaded: _react2.default.PropTypes.func

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export class Animation extends React.Component {
 
 export class Entity extends React.Component {
   static propTypes = {
-    children: React.PropTypes.array,
+    children: React.PropTypes.any,
     mixin: React.PropTypes.string,
     onClick: React.PropTypes.func,
     onLoaded: React.PropTypes.func


### PR DESCRIPTION
This will avoid warnings when supplying a single child. A more robust solution might be to explicitly require children to be one or more components, nodes, or even only specific types. The latter solution would require something like an additional class to be injected for ie. the Animation component, to avoid having to list specific components in the validation list.