### PR TITLE
Added check for the presence of el before attempting to attach event handler to it

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,12 +48,14 @@ var Animation = exports.Animation = (function (_React$Component) {
     }
 
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Animation)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.attachEvents = function (el) {
-      el.addEventListener('animationend', function (event) {
-        _this.props.onAnimationEnd(event);
-      });
-      el.addEventListener('animationstart', function (event) {
-        _this.props.onAnimationStart(event);
-      });
+      if (el) {
+        el.addEventListener('animationend', function (event) {
+          _this.props.onAnimationEnd(event);
+        });
+        el.addEventListener('animationstart', function (event) {
+          _this.props.onAnimationStart(event);
+        });
+      }
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
@@ -91,12 +93,14 @@ var Entity = exports.Entity = (function (_React$Component2) {
     }
 
     return _ret2 = (_temp2 = (_this2 = _possibleConstructorReturn(this, (_Object$getPrototypeO2 = Object.getPrototypeOf(Entity)).call.apply(_Object$getPrototypeO2, [this].concat(args))), _this2), _this2.attachEvents = function (el) {
-      el.addEventListener('click', function (event) {
-        _this2.props.onClick(event);
-      });
-      el.addEventListener('loaded', function (event) {
-        _this2.props.onLoaded(event);
-      });
+      if (el) {
+        el.addEventListener('click', function (event) {
+          _this2.props.onClick(event);
+        });
+        el.addEventListener('loaded', function (event) {
+          _this2.props.onLoaded(event);
+        });
+      }
     }, _temp2), _possibleConstructorReturn(_this2, _ret2);
   }
 
@@ -174,15 +178,17 @@ var Scene = exports.Scene = (function (_React$Component3) {
     }
 
     return _ret3 = (_temp3 = (_this4 = _possibleConstructorReturn(this, (_Object$getPrototypeO3 = Object.getPrototypeOf(Scene)).call.apply(_Object$getPrototypeO3, [this].concat(args))), _this4), _this4.attachEvents = function (el) {
-      el.addEventListener('loaded', function (event) {
-        _this4.props.onLoaded(event);
-      });
-      if (_this4.props.onTick) {
-        setTimeout(function () {
-          el.addBehavior({
-            update: _this4.props.onTick
-          });
+      if (el) {
+        el.addEventListener('loaded', function (event) {
+          _this4.props.onLoaded(event);
         });
+        if (_this4.props.onTick) {
+          setTimeout(function () {
+            el.addBehavior({
+              update: _this4.props.onTick
+            });
+          });
+        }
       }
     }, _temp3), _possibleConstructorReturn(_this4, _ret3);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ var Entity = exports.Entity = (function (_React$Component2) {
 })(_react2.default.Component);
 
 Entity.propTypes = {
-  children: _react2.default.PropTypes.array,
+  children: _react2.default.PropTypes.any,
   mixin: _react2.default.PropTypes.string,
   onClick: _react2.default.PropTypes.func,
   onLoaded: _react2.default.PropTypes.func

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,14 @@ export class Animation extends React.Component {
   };
 
   attachEvents = el => {
-    el.addEventListener('animationend', event => {
-      this.props.onAnimationEnd(event);
-    });
-    el.addEventListener('animationstart', event => {
-      this.props.onAnimationStart(event);
-    });
+    if (el) {
+      el.addEventListener('animationend', event => {
+        this.props.onAnimationEnd(event);
+      });
+      el.addEventListener('animationstart', event => {
+        this.props.onAnimationStart(event);
+      });
+    }
   }
 
   render() {
@@ -45,12 +47,14 @@ export class Entity extends React.Component {
   };
 
   attachEvents = el => {
-    el.addEventListener('click', event => {
-      this.props.onClick(event);
-    });
-    el.addEventListener('loaded', event => {
-      this.props.onLoaded(event);
-    });
+    if (el) {
+      el.addEventListener('click', event => {
+        this.props.onClick(event);
+      });
+      el.addEventListener('loaded', event => {
+        this.props.onLoaded(event);
+      });
+    }
   }
 
   /**
@@ -100,15 +104,17 @@ export class Scene extends React.Component {
   };
 
   attachEvents = el => {
-    el.addEventListener('loaded', event => {
-      this.props.onLoaded(event);
-    });
-    if (this.props.onTick) {
-      setTimeout(() => {
-        el.addBehavior({
-          update: this.props.onTick
-        });
+    if (el) {
+      el.addEventListener('loaded', event => {
+        this.props.onLoaded(event);
       });
+      if (this.props.onTick) {
+        setTimeout(() => {
+          el.addBehavior({
+            update: this.props.onTick
+          });
+        });
+      }
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export class Animation extends React.Component {
 
 export class Entity extends React.Component {
   static propTypes = {
-    children: React.PropTypes.array,
+    children: React.PropTypes.any,
     mixin: React.PropTypes.string,
     onClick: React.PropTypes.func,
     onLoaded: React.PropTypes.func


### PR DESCRIPTION
According to https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute, the ref callback attribute will be called with null when the referenced component is unmounted and whenever the ref changes.

When playing around with switching between normal 2d rendering and 3d rendering with A-Frame, I get null reference errors without this fix.

There should probable also be some calls to removeEventListener when the components are unmounted, but I haven't figured out where they would go yet.