### PR TITLE
Update Cursor related Event Listeners to match aframe#master (21d03002)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,17 +120,23 @@ var Entity = exports.Entity = function (_React$Component2) {
 
     return _ret2 = (_temp2 = (_this2 = _possibleConstructorReturn(this, (_Object$getPrototypeO2 = Object.getPrototypeOf(Entity)).call.apply(_Object$getPrototypeO2, [this].concat(args))), _this2), _this2.attachEvents = function (el) {
       if (el) {
-        el.addEventListener('click', function (event) {
+        el.addEventListener('cursor-click', function (event) {
           _this2.props.onClick(event);
         });
         el.addEventListener('loaded', function (event) {
           _this2.props.onLoaded(event);
         });
-        el.addEventListener('mouseenter', function (event) {
+        el.addEventListener('cursor-mouseenter', function (event) {
           _this2.props.onMouseEnter(event);
         });
-        el.addEventListener('mouseleave', function (event) {
+        el.addEventListener('cursor-mouseleave', function (event) {
           _this2.props.onMouseLeave(event);
+        });
+        el.addEventListener('cursor-mousedown', function (event) {
+          _this2.props.onMouseDown(event);
+        });
+        el.addEventListener('cursor-mouseup', function (event) {
+          _this2.props.onMouseUp(event);
         });
         el.addEventListener('child-attached', function (event) {
           _this2.props.onChildAttached(event);
@@ -178,6 +184,8 @@ Entity.propTypes = {
   onLoaded: _react2.default.PropTypes.func,
   onMouseEnter: _react2.default.PropTypes.func,
   onMouseLeave: _react2.default.PropTypes.func,
+  onMouseDown: _react2.default.PropTypes.func,
+  onMouseUp: _react2.default.PropTypes.func,
   onChildAttached: _react2.default.PropTypes.func,
   onComponentChanged: _react2.default.PropTypes.func,
   onPause: _react2.default.PropTypes.func,
@@ -190,6 +198,8 @@ Entity.defaultProps = {
   onLoaded: function onLoaded() {},
   onMouseEnter: function onMouseEnter() {},
   onMouseLeave: function onMouseLeave() {},
+  onMouseDown: function onMouseDown() {},
+  onMouseUp: function onMouseUp() {},
   onChildAttached: function onChildAttached() {},
   onComponentChanged: function onComponentChanged() {},
   onPause: function onPause() {},

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,8 @@ export class Entity extends React.Component {
     onLoaded: React.PropTypes.func,
     onMouseEnter: React.PropTypes.func,
     onMouseLeave: React.PropTypes.func,
+    onMouseDown: React.PropTypes.func,
+    onMouseUp: React.PropTypes.func,
     onChildAttached: React.PropTypes.func,
     onComponentChanged: React.PropTypes.func,
     onPause: React.PropTypes.func,
@@ -78,6 +80,8 @@ export class Entity extends React.Component {
     onLoaded: () => {},
     onMouseEnter: () => {},
     onMouseLeave: () => {},
+    onMouseDown: () => {},
+    onMouseUp: () => {},
     onChildAttached: () => {},
     onComponentChanged: () => {},
     onPause: () => {},
@@ -88,17 +92,23 @@ export class Entity extends React.Component {
 
   attachEvents = el => {
     if (el) {
-      el.addEventListener('click', event => {
+      el.addEventListener('cursor-click', event => {
         this.props.onClick(event);
       });
       el.addEventListener('loaded', event => {
         this.props.onLoaded(event);
       });
-      el.addEventListener('mouseenter', event => {
+      el.addEventListener('cursor-mouseenter', event => {
         this.props.onMouseEnter(event);
       });
-      el.addEventListener('mouseleave', event => {
+      el.addEventListener('cursor-mouseleave', event => {
         this.props.onMouseLeave(event);
+      });
+      el.addEventListener('cursor-mousedown', event => {
+        this.props.onMouseDown(event);
+      });
+      el.addEventListener('cursor-mouseup', event => {
+        this.props.onMouseUp(event);
       });
       el.addEventListener('child-attached', event => {
         this.props.onChildAttached(event);


### PR DESCRIPTION
According to the [aframe docs](https://aframe.io/docs/components/cursor.html#Events) and the source ([src/components/cursor.js#21d03002](https://github.com/aframevr/aframe/blob/21d030023dd404ce2b369f9936870ab6fbc73052/src/components/cursor.js)), the emitted events have changed since `v0.2.0`:

| Old event | New event |
| --- | --- |
| `click` | `cursor-click` |
| `mouseenter` | `cursor-mouseenter` |
| `mouseleave` | `cursor-mouseleave` |
| | `cursor-mouseup` |
| | `cursor-mousedown` |