### PR TITLE
Support custom entity names (a-sphere, a-box, etc)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.Scene = exports.Entity = undefined;
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 exports.serializeComponents = serializeComponents;
 
 var _react = require('react');
@@ -35,12 +36,11 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 /**
  * <a-entity>
  */
-
-var Entity = exports.Entity = (function (_React$Component) {
+var Entity = exports.Entity = function (_React$Component) {
   _inherits(Entity, _React$Component);
 
   function Entity() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -50,7 +50,7 @@ var Entity = exports.Entity = (function (_React$Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Entity)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.attachEvents = function (el) {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Entity.__proto__ || Object.getPrototypeOf(Entity)).call.apply(_ref, [this].concat(args))), _this), _this.attachEvents = function (el) {
       if (!el) {
         return;
       }
@@ -71,34 +71,33 @@ var Entity = exports.Entity = (function (_React$Component) {
         }
       });
 
-      return _react2.default.createElement(
-        'a-entity',
-        _extends({
-          ref: this.attachEvents
-        }, otherProps, serializeComponents(this.props)),
-        this.props.children
-      );
+      return _react2.default.createElement(this.props.entityName, Object.assign({ ref: this.attachEvents }, otherProps, serializeComponents(this.props)), this.props.children);
     }
   }]);
 
   return Entity;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 /**
  * <a-scene>
  */
 
+
 Entity.propTypes = {
   children: _react2.default.PropTypes.any,
   events: _react2.default.PropTypes.object,
-  mixin: _react2.default.PropTypes.string
+  mixin: _react2.default.PropTypes.string,
+  entityName: _react2.default.PropTypes.string
+};
+Entity.defaultProps = {
+  entityName: 'a-entity'
 };
 
-var Scene = exports.Scene = (function (_React$Component2) {
+var Scene = exports.Scene = function (_React$Component2) {
   _inherits(Scene, _React$Component2);
 
   function Scene() {
-    var _Object$getPrototypeO2;
+    var _ref2;
 
     var _temp2, _this3, _ret2;
 
@@ -108,7 +107,7 @@ var Scene = exports.Scene = (function (_React$Component2) {
       args[_key2] = arguments[_key2];
     }
 
-    return _ret2 = (_temp2 = (_this3 = _possibleConstructorReturn(this, (_Object$getPrototypeO2 = Object.getPrototypeOf(Scene)).call.apply(_Object$getPrototypeO2, [this].concat(args))), _this3), _this3.attachEvents = function (el) {
+    return _ret2 = (_temp2 = (_this3 = _possibleConstructorReturn(this, (_ref2 = Scene.__proto__ || Object.getPrototypeOf(Scene)).call.apply(_ref2, [this].concat(args))), _this3), _this3.attachEvents = function (el) {
       if (!el) {
         return;
       }
@@ -140,13 +139,14 @@ var Scene = exports.Scene = (function (_React$Component2) {
   }]);
 
   return Scene;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 /**
  * Serialize React props to A-Frame components.
  *
  * {primitive: box; width: 10} to 'primitive: box; width: 10'
  */
+
 
 Scene.propTypes = {
   events: _react2.default.PropTypes.object

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,12 @@ export class Entity extends React.Component {
   static propTypes = {
     children: React.PropTypes.any,
     events: React.PropTypes.object,
-    mixin: React.PropTypes.string
+    mixin: React.PropTypes.string,
+    entityName: React.PropTypes.string
+  };
+
+  static defaultProps = {
+    entityName: 'a-entity'
   };
 
   attachEvents = el => {
@@ -29,13 +34,14 @@ export class Entity extends React.Component {
       if (this.props[propName]) { otherProps[propName] = this.props[propName]; }
     });
 
-    return (
-      <a-entity
-        ref={this.attachEvents}
-        {...otherProps}
-        {...serializeComponents(this.props)}>
-        {this.props.children}
-      </a-entity>
+    return React.createElement(
+      this.props.entityName,
+      Object.assign(
+        { ref: this.attachEvents },
+        otherProps,
+        serializeComponents(this.props)
+      ),
+      this.props.children
     );
   }
 }

--- a/tests/react/index.test.js
+++ b/tests/react/index.test.js
@@ -56,6 +56,13 @@ describe('Entity', () => {
     ).toJSON();
     expect(tree.props.mixin).toBe('box');
   });
+
+  it('renders custom entity name', () => {
+    const tree = renderer.create(
+      <Entity entityName='a-sphere'/>
+    ).toJSON();
+    expect(tree.type).toBe('a-sphere');
+  });
 });
 
 describe('Scene', () => {


### PR DESCRIPTION
Enables adding event listeners to custom entities the "React Way" with the
events object, or the on* syntax:

```javascript
<Entity entityName='a-sphere' onClick={this.handleClick} />
```

Should fix #40 