### PR TITLE
Update Readme installation command with react-dom unmet peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for a basic example.
 ## Installation
 
 ```
-npm install --save aframe aframe-react react
+npm install --save aframe aframe-react react react-dom
 ```
 
 ## What `aframe-react` Does


### PR DESCRIPTION
Running the current command under the **Installation** heading displays the following after installing dependencies: `UNMET PEER DEPENDENCY react-dom@*`. Propose adding `react-dom` to the installation command to meet this peer dependency requirement for new installations.
My system: 
```
$ node -v
v7.0.0
$ npm -v
3.10.8
```