### PR TITLE
Allow setting properties that are not components for using primitive

### DIFF
--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -36,12 +36,6 @@ describe('serializeComponents', () => {
     assert.equal(output.sound__baa, '');
   });
 
-  it('excludes props that are not components', () => {
-    var output = serializeComponents({rose: 'blah', geometry: {}});
-    assert.ok(!('rose' in output));
-    assert.ok('geometry' in output);
-  });
-
   it('excludes children prop', () => {
     var output = serializeComponents({children: 'whatever'});
     assert.ok(!('children' in output));


### PR DESCRIPTION
shorthand mappings. Fixes #50 

*Does not yet work*. Looks like this causes entities to be created before the systems are initialized. Apply this patch to aframe-react-bootstrap and change a light to be `<Entity primitive='a-light' type='ambient' color='#888' />` to test. 

I get warnings of `'Uncaught TypeError: Cannot read property 'registerLight' of undefined'`, and same with geometry primitives -- the entities' `init` function is being called before the system's `init` function -- haven't dug deep enough into aframe internals to figure this one out yet :)