### PR TITLE
Allow antialias attribute to be set directly on the a-scene element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,12 @@ export function serializeComponents (props) {
 
     if (props[component] && props[component].constructor === Function) { return; }
 
+    // Antialias is not a component, but is supported at startup
+    if (component === 'antialias') {
+      serialProps.antialias = props[component];
+      return;
+    }
+
     var ind = Object.keys(components).indexOf(component.split('__')[0]);
     // Discards props that aren't components.
     if (ind === -1) { return; }
@@ -132,6 +138,7 @@ export function serializeComponents (props) {
       serialProps[component] = props[component];
     }
   });
+
   return serialProps;
 };
 

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -66,6 +66,11 @@ describe('serializeComponents', () => {
     var output = serializeComponents({position: null});
     assert.ok(output);
   });
+
+  it('allows antialias', () => {
+    var output = serializeComponents({antialias: 'true'});
+    assert.equal(output.antialias, 'true');
+  });
 });
 
 describe('getEventMappings', () => {


### PR DESCRIPTION
It is only parsed at startup by A-Frame, and not supported as a component.

This is a pretty specific implementation to allow for use of antialiasing, and with https://github.com/ngokevin/aframe-react/pull/51 and https://github.com/ngokevin/aframe-react/pull/43 pending I understand if you don't want to merge this. But I need antialiasing for my aframe-react project now, and perhaps other do too :)