### PR TITLE
Adding a check for if a component has not been set yet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,8 @@ export function serializeComponents (props) {
       return;
     }
 
+    if (props[component] === undefined) { return; }
+
     if (props[component].constructor === Function) { return; }
 
     var ind = Object.keys(components).indexOf(component.split('__')[0]);


### PR DESCRIPTION
I would get a lot of errors in my application at the line

` if (props[component].constructor === Function) { return; }`

because `props[component]` was not yet defined or waiting to load. I'm not sure why this issue came up for me, maybe I was misusing something in react, but adding this small line would remove the error but allow my content to load when it was ready/set by the user.