### PR TITLE
Fix mocking React public api instead of unexisting internals

### DIFF
--- a/tests/react/index.test.js
+++ b/tests/react/index.test.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 
 import {Entity, Scene} from '../../src/index.js';
 
-jest.mock('react/lib/ReactDefaultInjection');
+jest.mock('react-dom');
 
 global.AFRAME = {
   components: {


### PR DESCRIPTION
Hi @ngokevin 

That's a first step to contribute and add more unit test!

This fix just allows jest to mock `React-DOM` entirely. Since always the React team keep saying that our applications shoudn't rely on internal APIs, like (`react/lib/ReactDefaultInjection`).

With this fix, the jest tests work again.