### PR TITLE
handle null prop values when serializing components for #64

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,13 +101,15 @@ export function serializeComponents (props) {
 
     if (props[component] === undefined) { return; }
 
-    if (props[component].constructor === Function) { return; }
+    if (props[component] && props[component].constructor === Function) { return; }
 
     var ind = Object.keys(components).indexOf(component.split('__')[0]);
     // Discards props that aren't components.
     if (ind === -1) { return; }
 
-    if (props[component].constructor === Array) {
+    if (props[component] === null) {
+      serialProps[component] = null;
+    } else if (props[component].constructor === Array) {
       // Stringify components passed as array.
       serialProps[component] = props[component].join(' ');
     } else if (props[component].constructor === Object) {

--- a/tests/react/index.test.js
+++ b/tests/react/index.test.js
@@ -57,6 +57,13 @@ describe('Entity', () => {
     expect(tree.props.mixin).toBe('box');
   });
 
+  it('renders <a-entity> with null component', () => {
+    const tree = renderer.create(
+      <Entity position={null} />
+    ).toJSON();
+    expect(tree.props.position).toBe(null);
+  });
+
   it('renders primitive', () => {
     const tree = renderer.create(
       <Entity primitive='a-sphere' material={{color: 'red'}}/>

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -61,6 +61,11 @@ describe('serializeComponents', () => {
     var output = serializeComponents({className: 'my-cube'});
     assert.ok(output.class, 'my-cube');
   });
+
+  it('handles null prop values', () => {
+    var output = serializeComponents({position: null});
+    assert.ok(output);
+  });
 });
 
 describe('getEventMappings', () => {


### PR DESCRIPTION
check for a value before handling the prop

this also addresses when the prop value is `undefined`