### PR TITLE
Allow the "antialias" property to be set on the <a-scene> element.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export class Scene extends React.Component {
   render() {
     // Allow through normal attributes..
     const otherProps = {};
-    ['id', 'mixin'].forEach(propName => {
+    ['id', 'mixin', 'antialias'].forEach(propName => {
       if (this.props[propName]) { otherProps[propName] = this.props[propName]; }
     });
 

--- a/tests/react/index.test.js
+++ b/tests/react/index.test.js
@@ -83,4 +83,15 @@ describe('Scene', () => {
     expect(tree.type).toBe('a-scene');
     expect(tree.children[0].type).toBe('a-entity');
   });
+
+  it('renders <a-scene antialias="true">', () => {
+    const tree = renderer.create(
+      <Scene antialias='true'>
+        <Entity/>
+      </Scene>
+    ).toJSON();
+    expect(tree.type).toBe('a-scene');
+    expect(tree.props.antialias).toBe('true');
+  });
+
 });


### PR DESCRIPTION
It is only parsed at startup by A-Frame, and not supported as a component.